### PR TITLE
Adds config checks for file sink

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/tidwall/buntdb v1.1.2
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/go-playground/assert.v1 v1.2.1

--- a/io/flush_file_test.go
+++ b/io/flush_file_test.go
@@ -1,0 +1,142 @@
+package io
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/go-playground/assert.v1"
+)
+
+func TestLoadConfig(t *testing.T) {
+	errorConfigs := []struct {
+		Name         string
+		Path         string
+		ErrorMessage string
+		Setup        func(path string) error
+	}{
+		{
+			Name:         "Invalid path",
+			Path:         "/tmp/invalid-path",
+			ErrorMessage: "no such file or directory",
+			Setup: func(path string) error {
+				// Remove path if it already exists
+				if _, err := os.Stat(path); err == nil {
+					if err := os.Remove(path); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
+		{
+			Name:         "File Path",
+			Path:         "/tmp/file-path",
+			ErrorMessage: "not a directory",
+			Setup: func(path string) error {
+				// Create a file
+				if _, err := os.Create(path); err != nil {
+					t.Fatal(err)
+				}
+				return nil
+			},
+		},
+		{
+			Name:         "Read-only Directory",
+			Path:         "/tmp/read-only-dir",
+			ErrorMessage: "unable to access",
+			Setup: func(path string) error {
+				// Remove directory if it already exists
+				// and create a read-only directory
+				if _, err := os.Stat(path); err == nil {
+					if err := os.Remove(path); err != nil {
+						return err
+					}
+				}
+
+				if err := os.Mkdir(path, 0400); err != nil {
+					return err
+				}
+
+				return nil
+			},
+		},
+	}
+
+	validConfigs := []struct {
+		Name  string
+		Path  string
+		Setup func(path string) error
+	}{
+		{
+			Name: "Valid Directory",
+			Path: "/tmp/valid-directory",
+			Setup: func(path string) error {
+				// Remove directory if exists
+				// and create a new directory
+				if _, err := os.Stat(path); err == nil {
+					if err := os.Remove(path); err != nil {
+						return err
+					}
+				}
+
+				if err := os.Mkdir(path, 0700); err != nil {
+					return err
+				}
+
+				return nil
+			},
+		},
+	}
+
+	t.Run("Validate", func(t *testing.T) {
+		for _, test := range errorConfigs {
+			t.Run(test.Name, func(t *testing.T) {
+				path := test.Path
+
+				if err := test.Setup(path); err != nil {
+					t.Fatal(err)
+				}
+
+				rawConfig := json.RawMessage([]byte(fmt.Sprintf(
+					`{ "file_sink_dir": "%s" }`, path,
+				)))
+
+				fs := &FileSink{}
+
+				err := fs.LoadConfig(rawConfig)
+				if err == nil {
+					t.Fatal("Expects an error")
+				}
+
+				if !strings.Contains(err.Error(), test.ErrorMessage) {
+					t.Fatalf("Error should contain the message: %s", test.ErrorMessage)
+				}
+			})
+		}
+
+		for _, test := range validConfigs {
+			t.Run(test.Name, func(t *testing.T) {
+				path := test.Path
+
+				if err := test.Setup(path); err != nil {
+					t.Fatal(err)
+				}
+
+				rawConfig := json.RawMessage([]byte(fmt.Sprintf(
+					`{ "file_sink_dir": "%s" }`, path,
+				)))
+
+				fs := &FileSink{}
+
+				if err := fs.LoadConfig(rawConfig); err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, path, fs.Dir)
+			})
+		}
+	})
+}


### PR DESCRIPTION
This PR adds checks for the `file_sink_dir` config in `config.json`.

It handles the following cases:

- when `file_sink_dir` points to a non-existing path
```
$ k8stream --config=no-dir.json
2020/06/22 14:01:14 main.go:69: stat ./no-dir: no such file or directory
```

- when `file_sink_dir` points to a file instead of a directory
```
$ k8stream --config=file-config.json
2020/06/22 14:05:45 main.go:69: ./some-file is not a directory
```

- when `file_sink_dir` points to a read-only directory
```
$ k8stream --config=read-only.json
2020/06/22 14:01:34 main.go:69: unable to access ./read-only (permission denied)
```